### PR TITLE
Android behaves like OpenBSD and does not support AI_V4MAPPED

### DIFF
--- a/lib/pure/nativesockets.nim
+++ b/lib/pure/nativesockets.nim
@@ -233,7 +233,7 @@ proc getAddrInfo*(address: string, port: Port, domain: Domain = AF_INET,
   # OpenBSD doesn't support AI_V4MAPPED and doesn't define the macro AI_V4MAPPED.
   # FreeBSD doesn't support AI_V4MAPPED but defines the macro.
   # https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=198092
-  when not defined(freebsd) and not defined(openbsd) and not defined(netbsd):
+  when not defined(freebsd) and not defined(openbsd) and not defined(netbsd) and not defined(android):
     if domain == AF_INET6:
       hints.ai_flags = AI_V4MAPPED
   var gaiResult = getaddrinfo(address, $port, addr(hints), result)


### PR DESCRIPTION
See https://stackoverflow.com/questions/39674147/getaddrinfo-on-android-returning-error-eai-badflags for an in-depth explanation.